### PR TITLE
Update css selectors to allow photos

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -1,3 +1,3 @@
-#layers, [data-testid=mask], [data-testid=login], [data-testid=signup] {
+div.css-1dbjc4n.r-aqfbo4.r-1p0dtai.r-1d2f490.r-12vffkv.r-1xcajam.r-zchlnj, [data-testid=login], [data-testid=signup] {
   display: none !important;
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Less Annoying Twitter",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Hide login toolbar and login popup.",
    "permissions": ["scripting"],
   "icons": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Overview
I updated the CSS selectors to only select the login toolbar at the bottom of the page. 

## Background
After making my original change, I noticed that it was no longer possible to view photos in the photo viewer on the website. You could see a photo in a twitter and then click on the photo to enlarge it, but nothing would happen. I realized the issue was with the `id=layers` css selector, which may be too broad or used elsewhere. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing
You can clone down the repo and follow the instructions in the README for loading an unpacked extension. 
Then, navigate to twitter.com. You should be able to click on a photo and enlarge it, and the bottom banner should not be visible on desktops. 

<!--- Please describe in detail how to test these changes. -->

## Screenshot(s):

<!-- Please include any screenshots if applicable. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have self-reviewed my code and added comments where relevant.
- [ ] I have updated any relevant documentation.